### PR TITLE
Visibility issue with bootstrap installed

### DIFF
--- a/src/Resources/public/js/animations.js
+++ b/src/Resources/public/js/animations.js
@@ -1,6 +1,6 @@
 function xlAnimations() {
     $('.xl-animate').each(function () {
-        if ($(this).hasClass("visible")) {
+        if ($(this).hasClass("animated-visible")) {
             var effect = "animated " + $(this).data("effect");
             var delay = $(this).data("delay");
             if (delay > 0) {
@@ -14,7 +14,10 @@ function xlAnimations() {
     });
 }
 $(document).ready(function () {
-    $('.xl-animate').viewportChecker();
+    $('.xl-animate').viewportChecker({
+        classToAdd: 'animated-visible'
+    });
+
     xlAnimations();
 });
 


### PR DESCRIPTION
Hello,

at first thanks for the great plugin you've put together. Very useful :+1: 

Just one thing doesn't work. We use bootstrap 4. In the framework there's `_visibility.scss` which contains a css rule for the class `.visible` which applies to `visibility: visible !important`.

This results in the animated content element to be visible when it should be invsible for a small amount of time. See attached [video](https://github.com/hypergalaktisch/contao-animate/files/1449627/video.zip).

Solution is quite simple and implemented in my pull request. I changed the class `visible` to `animated-visible`. Now it works.

Could you please merge the request? Thanks in advance.

